### PR TITLE
Fix warning and invalid apt state

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -2,10 +2,9 @@
 - name: Ensure required packages are installed (apt)
   become: true
   apt:
-    pkg: "{{ item }}"
-    state: installed
-  with_items:
-    - make
+    pkg:
+      - make
+    state: present
 
 - name: Check if chruby is already installed
   stat:


### PR DESCRIPTION
Fixes two issues:

* 'installed' is no longer a valid state value in the latest Ansible.
* using `with_items` with apt is deprecated